### PR TITLE
fix: .mjs to .js

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,10 +1,5 @@
 {
   "index.js": {
-    "bundled": 5502,
-    "minified": 2876,
-    "gzipped": 1043
-  },
-  "index.mjs": {
     "bundled": 4649,
     "minified": 2139,
     "gzipped": 925,
@@ -19,11 +14,6 @@
     }
   },
   "vanilla.js": {
-    "bundled": 7203,
-    "minified": 3456,
-    "gzipped": 1298
-  },
-  "vanilla.mjs": {
     "bundled": 6624,
     "minified": 3127,
     "gzipped": 1218,
@@ -38,11 +28,6 @@
     }
   },
   "utils.js": {
-    "bundled": 8427,
-    "minified": 4012,
-    "gzipped": 1497
-  },
-  "utils.mjs": {
     "bundled": 7137,
     "minified": 3388,
     "gzipped": 1425,
@@ -57,11 +42,6 @@
     }
   },
   "macro.js": {
-    "bundled": 2595,
-    "minified": 1413,
-    "gzipped": 693
-  },
-  "macro.mjs": {
     "bundled": 1366,
     "minified": 890,
     "gzipped": 508,

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "1.1.1",
   "description": "💊 Valtio makes proxy-state simple for React and Vanilla",
   "main": "./index.js",
-  "module": "./esm/index.mjs",
+  "module": "./esm/index.js",
   "types": "index.d.ts",
   "typesVersions": {
     "<4.0": {
@@ -21,26 +21,26 @@
     "./": "./",
     ".": {
       "types": "./index.d.ts",
-      "module": "./esm/index.mjs",
-      "import": "./esm/index.mjs",
+      "module": "./esm/index.js",
+      "import": "./esm/index.js",
       "default": "./index.js"
     },
     "./vanilla": {
       "types": "./vanilla.d.ts",
-      "module": "./esm/vanilla.mjs",
-      "import": "./esm/vanilla.mjs",
+      "module": "./esm/vanilla.js",
+      "import": "./esm/vanilla.js",
       "default": "./vanilla.js"
     },
     "./utils": {
       "types": "./utils.d.ts",
-      "module": "./esm/utils.mjs",
-      "import": "./esm/utils.mjs",
+      "module": "./esm/utils.js",
+      "import": "./esm/utils.js",
       "default": "./utils.js"
     },
     "./macro": {
       "types": "./macro.d.ts",
-      "module": "./esm/macro.mjs",
-      "import": "./esm/macro.mjs",
+      "module": "./esm/macro.js",
+      "import": "./esm/macro.js",
       "default": "./macro.js"
     }
   },

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -77,12 +77,12 @@ export default function (args) {
     c = c.slice('config-'.length)
     return [
       createCommonJSConfig(`src/${c}.ts`, `dist/${c}.js`),
-      createESMConfig(`src/${c}.ts`, `dist/esm/${c}.mjs`),
+      createESMConfig(`src/${c}.ts`, `dist/esm/${c}.js`),
     ]
   }
   return [
     createDeclarationConfig('src/index.ts', 'dist'),
     createCommonJSConfig('src/index.ts', 'dist/index.js'),
-    createESMConfig('src/index.ts', 'dist/esm/index.mjs'),
+    createESMConfig('src/index.ts', 'dist/esm/index.js'),
   ]
 }


### PR DESCRIPTION
figured that .mjs is not needed for most bundlers and
causing issues with babel-loader for webpack so changed it back